### PR TITLE
Modify ancom input

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run benchmarks
         run: |
           # Run quick benchmarks on all versions to test everything works
-          asv run HASHFILE:versions.txt --quick
+          asv run --skip-existing-commits HASHFILE:versions.txt
 
       - name: Generate HTML
         run: asv publish

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -60,7 +60,7 @@ jobs:
           echo "When this PR is merged, the production workflow will run and deploy to GitHub Pages."
 
       - name: Upload test results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-test-results
           path: .asv/html/

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run benchmarks
         run: |
           # Run quick benchmarks on all versions to test everything works
-          asv run --skip-existing-commits HASHFILE:versions.txt
+          asv run --skip-existing-commits --show-stderr HASHFILE:versions.txt
 
       - name: Generate HTML
         run: asv publish

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -58,13 +58,13 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.asv/html'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Summary
         run: |

--- a/README.rst
+++ b/README.rst
@@ -65,20 +65,11 @@ Local Development
 Triggering Benchmarking
 -----------------------
 
-This repository uses GitHub Actions to automatically benchmark new scikit-bio releases:
+This repository uses GitHub Actions to benchmark new scikit-bio releases. To add one:
 
-1. **Manual Trigger**: Go to Actions → "Benchmark Specific Releases" → "Run workflow"
-2. **Add New Version**: Enter the new release version (e.g., ``0.6.4``)
-3. **Deploy**: Results are automatically published to GitHub Pages
-
-The workflow will:
-
-- Add the new version to ``versions.txt``
-- Run benchmarks for the specified version
-- Generate HTML reports
-- Deploy to GitHub Pages
-- Commit the updated version list
-
+1. **Open a PR**: Add the new release version (e.g., ``0.7.3``) to ``versions.txt``.
+2. **Test run**: Opening the PR triggers a benchmark run to verify everything works. No results are deployed.
+3. **Merge**: Merging the PR runs the full benchmarks and deploys the HTML reports to GitHub Pages.
 
 Configuration
 -------------

--- a/benchmarks/stats.py
+++ b/benchmarks/stats.py
@@ -58,13 +58,23 @@ class Ordination:
 
 class Composition:
     def setup(self):
+        # size = 500
+        # self.mat = np.random.rand(size, size)
+        # self.df = pd.DataFrame(data=self.mat)
+        # # make a random matrix with some zeros in it
+        # self.mat_z = self.mat * (self.mat > 0.2)
+        # rng = np.random.default_rng(seed=42)
+        # self.groups = pd.Series(data=rng.integers(2, size=size).astype(str))
+
         size = 500
-        self.mat = np.random.rand(size, size)
-        self.df = pd.DataFrame(data=self.mat)
-        # make a random matrix with some zeros in it
+        ids = [f"s{i}" for i in range(size)]
+        # strictly positive data for compositional methods
+        self.mat = np.random.default_rng(42).random((size, size)) + 1e-6
+        self.df = pd.DataFrame(self.mat, index=ids)
         self.mat_z = self.mat * (self.mat > 0.2)
         rng = np.random.default_rng(seed=42)
-        self.groups = pd.Series(data=rng.integers(2, size=size).astype(str))
+        self.groups = pd.Series(rng.integers(2, size=size).astype(str), index=ids)
+
 
     def time_clr(self):
         return clr(self.mat)

--- a/benchmarks/stats.py
+++ b/benchmarks/stats.py
@@ -58,22 +58,23 @@ class Ordination:
 
 class Composition:
     def setup(self):
-        # size = 500
-        # self.mat = np.random.rand(size, size)
-        # self.df = pd.DataFrame(data=self.mat)
-        # # make a random matrix with some zeros in it
-        # self.mat_z = self.mat * (self.mat > 0.2)
-        # rng = np.random.default_rng(seed=42)
-        # self.groups = pd.Series(data=rng.integers(2, size=size).astype(str))
-
         size = 500
-        ids = [f"s{i}" for i in range(size)]
-        # strictly positive data for compositional methods
-        self.mat = np.random.default_rng(42).random((size, size)) + 1e-6
-        self.df = pd.DataFrame(self.mat, index=ids)
+        n_feats = 30
+        self.mat = np.random.rand(size, n_feats)
+        self.df = pd.DataFrame(data=self.mat)
+        # make a random matrix with some zeros in it
         self.mat_z = self.mat * (self.mat > 0.2)
         rng = np.random.default_rng(seed=42)
-        self.groups = pd.Series(rng.integers(2, size=size).astype(str), index=ids)
+        self.groups = pd.Series(data=rng.integers(2, size=size).astype(str))
+
+        # size = 500
+        # ids = [f"s{i}" for i in range(size)]
+        # # strictly positive data for compositional methods
+        # self.mat = np.random.default_rng(42).random((size, size)) + 1e-6
+        # self.df = pd.DataFrame(self.mat, index=ids)
+        # self.mat_z = self.mat * (self.mat > 0.2)
+        # rng = np.random.default_rng(seed=42)
+        # self.groups = pd.Series(rng.integers(2, size=size).astype(str), index=ids)
 
 
     def time_clr(self):

--- a/benchmarks/stats.py
+++ b/benchmarks/stats.py
@@ -59,23 +59,13 @@ class Ordination:
 class Composition:
     def setup(self):
         size = 500
-        n_feats = 30
+        n_feats = 50
         self.mat = np.random.rand(size, n_feats)
         self.df = pd.DataFrame(data=self.mat)
         # make a random matrix with some zeros in it
         self.mat_z = self.mat * (self.mat > 0.2)
         rng = np.random.default_rng(seed=42)
         self.groups = pd.Series(data=rng.integers(2, size=size).astype(str))
-
-        # size = 500
-        # ids = [f"s{i}" for i in range(size)]
-        # # strictly positive data for compositional methods
-        # self.mat = np.random.default_rng(42).random((size, size)) + 1e-6
-        # self.df = pd.DataFrame(self.mat, index=ids)
-        # self.mat_z = self.mat * (self.mat > 0.2)
-        # rng = np.random.default_rng(seed=42)
-        # self.groups = pd.Series(rng.integers(2, size=size).astype(str), index=ids)
-
 
     def time_clr(self):
         return clr(self.mat)


### PR DESCRIPTION
The error in previous runs of the `ancom` benchmarks was simply due to the input being too large. The original version had 500 features. This PR brings it down to 50 features. This avoids the timeout errors. 

Additionally, some documentation is improved and the github-actions versions are updated.